### PR TITLE
Implement context files

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,17 @@
+# CITATION.cff
+
+# Citation Information
+preferred-citation: |
+  jutils. (2023). GitHub repository. https://github.com/JordanWelsman/jutils
+
+# Contributors
+contributors:
+- name: Jordan Welsman
+  affiliation: Bournemouth University
+  orcid: 0000-0002-2882-594X
+
+# Version
+version: 0.4.1
+
+# Date
+date-released: 2023-01-18

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,17 +1,10 @@
-# CITATION.cff
-
-# Citation Information
-preferred-citation: |
-  jutils. (2023). GitHub repository. https://github.com/JordanWelsman/jutils
-
-# Contributors
-contributors:
-- name: Jordan Welsman
-  affiliation: Bournemouth University
-  orcid: 0000-0002-2882-594X
-
-# Version
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Welsman"
+  given-names: "Jordan"
+  orcid: "https://orcid.org/0000-0002-2882-594X"
+title: "jutils"
 version: 0.4.1
-
-# Date
-date-released: 2023-01-18
+date-released: 2023-02-18
+url: "https://github.com/JordanWelsman/jutils"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code Owners
+
+# Assigned as reviewer for all PRs
+*   @JordanWelsman

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,24 +1,83 @@
-# Code of Conduct
+# Contributor Covenant Code of Conduct
 
-As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests, and other activities.
+## Our Pledge
 
-We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
 
-Examples of unacceptable behavior by participants include:
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
-- The use of sexualized language or imagery
-- Personal attacks
-- Trolling or insulting/derogatory comments
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
-- Publishing other's private information, such as physical or electronic addresses, without explicit permission
-- Other unethical or unprofessional conduct
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+## Enforcement Responsibilities
 
-This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [insert email address]. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+## Scope
 
-Thank you for contributing to this project and making it a welcoming and friendly community for everyone!
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement [here](mailto:jordan.welsman@outlook.com). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,24 @@
+# Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery
+- Personal attacks
+- Trolling or insulting/derogatory comments
+- Public or private harassment
+- Publishing other's private information, such as physical or electronic addresses, without explicit permission
+- Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [insert email address]. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Thank you for contributing to this project and making it a welcoming and friendly community for everyone!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to jutils
+
+Thank you for your interest in contributing towards this project. The owners of this repository welcome contributions from the open source community with open arms.
+
+## Getting started
+
+Please review the [Code of Conduct](CODE_OF_CONDUCT.md) to get familiar the dos and don'ts of contributing. Please also see our [contributing guidelines](#how-to-contribute), which provides a general reference on the process of contributing to the project.
+
+## How to contribute
+
+We welcome contributions in many forms, including bug reports, feature requests, documentation improvements, and code contributions. To get started, please follow these steps:
+
+### Request a feature or propose an idea
+
+1. Create a new post on the [Discussion Board](https://github.com/JordanWelsman/jutils/discussions).
+2. Work with the existing developers on a plan of implementation.
+3. Fork this repository and create a new branch for your contribution.
+4. Make your changes and commit them to your branch.
+5. Submit a pull request to this repository.
+6. We will review your changes and provide feedback as needed.
+
+### Report or fix a bug
+
+1. Submit a GitHub issue to the issue tracker.
+2. If you would like to fix the bug yourself, comment that you want to work on it.
+3. Once you have approval, fork this repository and create a new branch for your bugfix.
+4. Make your changes and commit them to your branch.
+5. Submit a pull request to this repository.
+6. We will review your changes and provide feedback as needed.
+
+> If you need advice on your contribution or context on the project code, don't hesitate to reach out on our [Discussion Board](https://github.com/JordanWelsman/jutils/discussions).
+
+
+## Code ownership
+
+Once you have successfuly contributed to this project, you should add yourself to the [Code Owners](CODEOWNERS) directory. This will notify you any time someone wants to further add to your contribution.
+
+_Happy contributing!_ :pen:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,17 @@
 # Security Policy
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
 If you discover a security vulnerability within this project, please send an email to [Jordan Welsman](mailto:jordan.welsman@ooutlook.com). All security vulnerabilities will be promptly addressed.
 
 Please do not publicly disclose any security vulnerabilities until they have been addressed by the project maintainers.
+
+## Supported versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.4.x   | :white_check_mark: |
+| 0.3.x   | :x:                |
+| 0.2.x   | :x:                |
+| 0.1.x   | :x:                |
+| 0.0.x   | :x:                |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability within this project, please send an email to [Jordan Welsman](mailto:jordan.welsman@ooutlook.com). All security vulnerabilities will be promptly addressed.
+
+Please do not publicly disclose any security vulnerabilities until they have been addressed by the project maintainers.


### PR DESCRIPTION
# Description

This pull request seeks to implement files which give context options to a GitHub repository.

# To-do:

- [x] Add CITATION.cff
- [x] Add CODE_OF_CONDUCT.md
- [x] Add CODEOWNERS
- [x] Add CONTRIBUTING.md
- [x] Add SECURITY.md