### PR TITLE
Fix out-of-bounds return error

### DIFF
--- a/jutl/__init__.py
+++ b/jutl/__init__.py
@@ -1,5 +1,5 @@
 # Dunder attributes
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __author__ = "Jordan Welsman"
 __license__ = "MIT"
 __copyright__ = "Copyright 2023 Jordan Welsman"

--- a/jutl/datastructures/stack.py
+++ b/jutl/datastructures/stack.py
@@ -125,7 +125,10 @@ class Stack(object):
 
     @property
     def top(self) -> object:
-        return self._stack[-1]
+        if len(self) > 0:
+            return self._stack[-1]
+        else:
+            raise IndexError("Stack is empty.")
 
 
     def extend(self, other: Stack) -> Stack:

--- a/jutl/datastructures/stack.py
+++ b/jutl/datastructures/stack.py
@@ -118,8 +118,9 @@ class Stack(object):
         """
         Removes the last added item from the stack.
         """
+        popped = self.top
         self._stack.remove(self.top)
-        return self.top
+        return popped
 
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # Arguments
 git_name = "jutils"
 pypi_name = "jutl"
-version = "0.5.0" # update __init__.py
+version = "0.5.1" # update __init__.py
 python_version = ">=3.10"
 
 # Long description from README.md

--- a/test/datastructures/test_stack.py
+++ b/test/datastructures/test_stack.py
@@ -159,6 +159,44 @@ class TestDunder():
 
 
 class TestRobustness():
+    def test_push(self):
+        """
+        Checks if pushing an
+        item to a stack works.
+        """
+        stack = Stack()
+        stack.push(test_item)
+        assert len(stack) == 1
+        del(stack)
+
+        stack = Stack()
+        stack.push(test_item)
+        stack.push(test_item)
+        assert len(stack) == 2
+        del(stack)
+
+        stack = Stack()
+        stack.push(test_item, test_item, test_item)
+        assert len(stack) == 3
+        del(stack)
+
+    def test_pop(self):
+        """
+        Checks if popping an
+        item from a stack works.
+        """
+        stack = Stack()
+        stack.push(test_item, test_item, test_item)
+        assert stack.pop() == test_item
+        assert len(stack) == 2
+        del(stack)
+
+        stack = Stack()
+        stack.push(test_item)
+        assert stack.pop() == test_item
+        assert len(stack) == 0
+        del(stack)
+
     def test_extend(self):
         """
         Checks if the extend


### PR DESCRIPTION
# Description

This pull request fixes the out-of-bounds return error when popping the last item from a stack. The bug occurred when popping a stack with one element as the stack tries to return the `top` value after it has been removed, resulting in an out-of-bounds access exception. `top` itself was also fixed and is now prevented from attempting to access the last element in a zero-element stack.

# To-do:

- [x] Assign `top` to variable before popping and return the variable instead.
- [x] In `top`, check the length of the stack and only return the last element if the stack is not empty, otherwise raise an exception.