### PR TITLE
0.5 bugfixes

### DIFF
--- a/jutl/__init__.py
+++ b/jutl/__init__.py
@@ -1,5 +1,5 @@
 # Dunder attributes
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __author__ = "Jordan Welsman"
 __license__ = "MIT"
 __copyright__ = "Copyright 2023 Jordan Welsman"

--- a/jutl/datastructures/stack.py
+++ b/jutl/datastructures/stack.py
@@ -118,13 +118,17 @@ class Stack(object):
         """
         Removes the last added item from the stack.
         """
+        popped = self.top
         self._stack.remove(self.top)
-        return self.top
+        return popped
 
 
     @property
     def top(self) -> object:
-        return self._stack[-1]
+        if len(self) > 0:
+            return self._stack[-1]
+        else:
+            raise IndexError("Stack is empty.")
 
 
     def extend(self, other: Stack) -> Stack:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # Arguments
 git_name = "jutils"
 pypi_name = "jutl"
-version = "0.5.0" # update __init__.py
+version = "0.5.1" # update __init__.py
 python_version = ">=3.10"
 
 # Long description from README.md

--- a/test/datastructures/test_stack.py
+++ b/test/datastructures/test_stack.py
@@ -159,6 +159,44 @@ class TestDunder():
 
 
 class TestRobustness():
+    def test_push(self):
+        """
+        Checks if pushing an
+        item to a stack works.
+        """
+        stack = Stack()
+        stack.push(test_item)
+        assert len(stack) == 1
+        del(stack)
+
+        stack = Stack()
+        stack.push(test_item)
+        stack.push(test_item)
+        assert len(stack) == 2
+        del(stack)
+
+        stack = Stack()
+        stack.push(test_item, test_item, test_item)
+        assert len(stack) == 3
+        del(stack)
+
+    def test_pop(self):
+        """
+        Checks if popping an
+        item from a stack works.
+        """
+        stack = Stack()
+        stack.push(test_item, test_item, test_item)
+        assert stack.pop() == test_item
+        assert len(stack) == 2
+        del(stack)
+
+        stack = Stack()
+        stack.push(test_item)
+        assert stack.pop() == test_item
+        assert len(stack) == 0
+        del(stack)
+
     def test_extend(self):
         """
         Checks if the extend


### PR DESCRIPTION
# Description

This pull request fixes a bug with the Stack implementation when an out-of-bounds error occurs when using `pop` with a zero-element stack.

# To-do:

- [x] Issue bugfix
- [x] Write tests to verify bugfix